### PR TITLE
Spigot clarification

### DIFF
--- a/doc_source/aws-glue-api-crawler-pyspark-extensions-dynamic-frame.md
+++ b/doc_source/aws-glue-api-crawler-pyspark-extensions-dynamic-frame.md
@@ -235,7 +235,7 @@ Returns a new `DynamicFrame` containing the selected fields\.
 
 Writes sample records to a specified destination during a transformation, and returns the input `DynamicFrame` with an additional write step\.
 + `path` – The path to the destination to which to write \(required\)\.
-+ `options` – Key\-value pairs specifying options \(optional\)\. The `"topk"` option specifies that the first `k` records should be written\. The `"prob"` option specifies the probability of picking any given record, to be used in selecting records to write\.
++ `options` – Key\-value pairs specifying options \(optional\)\. The `"topk"` option specifies that the first `k` records should be written\. The `"prob"` option specifies the probability (as a decimal) of picking any given record, to be used in selecting records to write\.
 + `transformation_ctx` – A unique string that is used to identify state information \(optional\)\.
 
 ## split\_fields<a name="aws-glue-api-crawler-pyspark-extensions-dynamic-frame-split_fields"></a>


### PR DESCRIPTION
Calling out that the "prob" option on the Spigot needs to be given as a decimal.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
