### PR TITLE
Spigot clarification

### DIFF
--- a/doc_source/aws-glue-api-crawler-pyspark-transforms-spigot.md
+++ b/doc_source/aws-glue-api-crawler-pyspark-transforms-spigot.md
@@ -17,7 +17,7 @@ Writes sample records to a specified destination during a transformation\.
 Writes sample records to a specified destination during a transformation\.
 + `frame` – The `DynamicFrame` to spigot \(required\)\.
 + `path` – The path to the destination to write to \(required\)\.
-+ `options` – JSON key\-value pairs specifying options \(optional\)\. The `"topk"` option specifies that the first k records should be written\. The `"prob"` option specifies the probability of picking any given record, to be used in selecting records to write\.
++ `options` – JSON key\-value pairs specifying options \(optional\)\. The `"topk"` option specifies that the first k records should be written\. The `"prob"` option specifies the probability (as a decimal) of picking any given record, to be used in selecting records to write\.
 + `transformation_ctx` – A unique string that is used to identify state information \(optional\)\.
 
 Returns the input `DynamicFrame` with an additional write step\.


### PR DESCRIPTION
Calling out that the "prob" option on the Spigot needs to be given as a decimal.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
