### PR TITLE
Updated ApplyMapping for column names with periods

### DIFF
--- a/doc_source/aws-glue-api-crawler-pyspark-transforms-ApplyMapping.md
+++ b/doc_source/aws-glue-api-crawler-pyspark-transforms-ApplyMapping.md
@@ -17,6 +17,12 @@ Applies a mapping in a `DynamicFrame`\.
 Applies a declarative mapping to a specified `DynamicFrame`\.
 + `frame` – The `DynamicFrame` in which to apply the mapping \(required\)\.
 + `mappings` – A list of mapping tuples, each consisting of: \(source column, source type, target column, target type\)\. Required\.
+
+  If the source column has dots in it, the mapping will not work unless you place back\-ticks around it \(\`\`\)\. For example, to map `this.old.name` (string) to `thisNewName` (string), you would use the following tuple:
+
+  ```
+  ("`this.old.name`", "string", "thisNewName", "string")
+  ```
 + `transformation_ctx` – A unique string that is used to identify state information \(optional\)\.
 + `info` – A string associated with errors in the transformation \(optional\)\.
 + `stageThreshold` – The maximum number of errors that can occur in the transformation before it errors out \(optional; the default is zero\)\.

--- a/doc_source/aws-glue-api-crawler-pyspark-transforms-RenameField.md
+++ b/doc_source/aws-glue-api-crawler-pyspark-transforms-RenameField.md
@@ -18,7 +18,7 @@ Renames a node within a `DynamicFrame`\.
 + `frame` – The `DynamicFrame` in which to rename a node \(required\)\.
 + `old_name` – Full path to the node to rename \(required\)\.
 
-  If the old name has dots in it, RenameField will not work unless you place back\-ticks around it \(```\)\. For example, to replace `this.old.name` with `thisNewName`, you would call RenameField as follows:
+  If the old name has dots in it, RenameField will not work unless you place back\-ticks around it \(\`\`\)\. For example, to replace `this.old.name` with `thisNewName`, you would call RenameField as follows:
 
   ```
   newDyF = RenameField(oldDyF, "`this.old.name`", "thisNewName")


### PR DESCRIPTION
*Issue #, if available:*

Updated ApplyMapping to describe how to handle column names containing periods, as is described in RenameFields.
Minor formatting updates to RenameFields.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
