### PR TITLE
Fix typo : "command" to "Command"

### DIFF
--- a/doc_source/aws-glue-programming-python-calling.md
+++ b/doc_source/aws-glue-programming-python-calling.md
@@ -14,7 +14,7 @@ In Python calls to AWS Glue APIs, it's best to pass parameters explicitly by nam
 
 ```
 job = glue.create_job(Name='sample', Role='Glue_DefaultRole',
-                      command={'Name': 'glueetl',
+                      Command={'Name': 'glueetl',
                                'ScriptLocation': 's3://my_script_bucket/scripts/my_etl_script.py'})
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Minor typo fix.

Got the following error when using the current example: 
```
Missing required parameter in input: "Command"
Unknown parameter in input: "command", must be one of: Name, Description, LogUri, Role, ExecutionProperty, Command, DefaultArguments, Connections, MaxRetries, AllocatedCapacity, Timeout, NotificationProperty, SecurityConfiguration
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
