### PR TITLE
Clarify these instructions are only for Spark ETL

### DIFF
--- a/doc_source/aws-glue-programming-python-libraries.md
+++ b/doc_source/aws-glue-programming-python-libraries.md
@@ -2,6 +2,8 @@
 
 You can use Python extension modules and libraries with your AWS Glue ETL scripts as long as they are written in pure Python\. C libraries such as `pandas` are not supported at the present time, nor are extensions written in other languages\.
 
+Note that the instructions below on Zipping libraries only applies to Spark ETL scripts. Python libraries for Python Shell scripts should be packaged as `.egg` files instead, as described in [Providing Your Own Python Library](add-job-python.md#providing-your-own-python-library).
+
 ## Zipping Libraries for Inclusion<a name="aws-glue-programming-python-libraries-zipping"></a>
 
 Unless a library is contained in a single `.py` file, it should be packaged in a `.zip` archive\. The package directory should be at the root of the archive, and must contain an `__init__.py` file for the package\. Python will then be able to import the package in the normal way\.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

I'm adding a sentence explaining that the instructions about Zipping libraries only applies to Spark ETL scripts, because we've lost a few hours on trying to use a Python Shell job with zipped libraries and eventually found that libraries shouldn't be zipped for Python Shell jobs, they should be packaged as `.egg`s. Having this in the documentation would have saved us a lot of time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.