### PR TITLE
update glue etl format options comment for json

### DIFF
--- a/doc_source/aws-glue-programming-etl-format.md
+++ b/doc_source/aws-glue-programming-etl-format.md
@@ -46,6 +46,8 @@ You can use the following `format_options` values with `format="grokLog"`:
 
 This value designates a [JSON](https://www.json.org/) \(JavaScript Object Notation\) data format\.
 
+**Currently, AWS Glue does not support `format_options` for `json` output\.**
+
 You can use the following `format_options` values with `format="json"`:
 + `jsonPath`: A [JsonPath](https://github.com/json-path/JsonPath) expression that identifies an object to be read into records\. This is particularly useful when a file contains records nested inside an outer array\. For example, the following JsonPath expression targets the `id` field of a JSON object:
 


### PR DESCRIPTION
Documentation for Glue ETL job connection formats, it was unclear which options applied to reads (sources) and write(targets). Added a comment specifically for `json` format. I discovered this through a support case when trying to use `format_options` with a target/destination.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
