### PR TITLE
Fix usage for SelectFromCollection class

### DIFF
--- a/doc_source/aws-glue-api-crawler-pyspark-transforms-SelectFromCollection.md
+++ b/doc_source/aws-glue-api-crawler-pyspark-transforms-SelectFromCollection.md
@@ -15,7 +15,8 @@ Selects one `DynamicFrame` in a `DynamicFrameCollection`\.
 ## \_\_call\_\_\(dfc, key, transformation\_ctx = ""\)<a name="aws-glue-api-crawler-pyspark-transforms-SelectFromCollection-__call__"></a>
 
 Gets one `DynamicFrame` from a `DynamicFrameCollection`\.
-+ `dfc` – The key of the `DynamicFrame` to select \(required\)\.
++ `dfc` - The `DynamicFrameCollection` from which the `DynamicFrame` should be selected \(required\)\.
++ `key` – The key of the `DynamicFrame` to select \(required\)\.
 + `transformation_ctx` – A unique string that is used to identify state information \(optional\)\.
 
 Returns the specified `DynamicFrame`\.


### PR DESCRIPTION
*Issue #, if available:* Not Available

*Description of changes:* Fixed the arguments and descriptions included in the SelectFromCollection.__call__() method. Source code with correct usage can be found here: [awslabs/aws-glue-libs/blob/master/awsglue/transforms/collection_transforms.py#L21](https://github.com/awslabs/aws-glue-libs/blob/968179ff4fb097e7fca41d268757ac6b0c7e90c5/awsglue/transforms/collection_transforms.py#L21)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
