### PR TITLE
Updated maven link

### DIFF
--- a/doc_source/aws-glue-programming-etl-libraries.md
+++ b/doc_source/aws-glue-programming-etl-libraries.md
@@ -30,7 +30,7 @@ Complete these steps to prepare for local Python development:
 
 1. Download the AWS Glue Python library from github \([https://github.com/awslabs/aws-glue-libs](https://github.com/awslabs/aws-glue-libs)\)\.
 
-1. Install Apache Maven from the following location: [http://apache.mirrors.tds.net/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz](http://apache.mirrors.tds.net/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz)\.
+1. Install Apache Maven from the following location: [https://archive.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz](https://archive.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz)\.
 
 1. Install the Apache Spark distribution from the following location: [ https://archive.apache.org/dist/spark/spark-2.2.1/spark-2.2.1-bin-hadoop2.7.tgz]( https://archive.apache.org/dist/spark/spark-2.2.1/spark-2.2.1-bin-hadoop2.7.tgz)\.
 


### PR DESCRIPTION
Link http://apache.mirrors.tds.net/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz is dead as maven released a new version (v3.6.2).

*Issue #, if available:*

*Description of changes:* Maven download link is dead

use binaries from https://archive.apache.org/dist/maven/maven-3/ to avoid updating the links again and again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
