### PR TITLE
Update aws-glue-api-crawler-pyspark-extensions-dynamic-frame.md

### DIFF
--- a/doc_source/aws-glue-api-crawler-pyspark-extensions-dynamic-frame.md
+++ b/doc_source/aws-glue-api-crawler-pyspark-extensions-dynamic-frame.md
@@ -52,6 +52,9 @@ A `DynamicRecord` represents a logical record in a `DynamicFrame`\. It is simila
 + [schema](#aws-glue-api-crawler-pyspark-extensions-dynamic-frame-schema)
 + [printSchema](#aws-glue-api-crawler-pyspark-extensions-dynamic-frame-printSchema)
 + [show](#aws-glue-api-crawler-pyspark-extensions-dynamic-frame-show)
++ [show](#aws-glue-api-crawler-pyspark-extensions-dynamic-frame-repartition)
++ [show](#aws-glue-api-crawler-pyspark-extensions-dynamic-frame-coalesce)
+
 
 ## count<a name="aws-glue-api-crawler-pyspark-extensions-dynamic-frame-count"></a>
 
@@ -68,6 +71,15 @@ A `DynamicRecord` represents a logical record in a `DynamicFrame`\. It is simila
 ## show<a name="aws-glue-api-crawler-pyspark-extensions-dynamic-frame-show"></a>
 
 `show(num_rows)` – Prints a specified number of rows from the underlying `DataFrame`\.
+
+## repartition<a name="aws-glue-api-crawler-pyspark-extensions-dynamic-frame-repartition"></a>
+
+`repartition(numPartitions)` – Returns a new DynamicFrame with numPartitions partitions.\.
+
+## coalesce<a name="aws-glue-api-crawler-pyspark-extensions-dynamic-frame-coalesce"></a>
+
+`coalesce(numPartitions)` – Returns a new DynamicFrame with numPartitions partitions.\.
+
 
 ##  — Transforms —<a name="aws-glue-api-crawler-pyspark-extensions-dynamic-frame-_transforms"></a>
 + [apply\_mapping](#aws-glue-api-crawler-pyspark-extensions-dynamic-frame-apply_mapping)


### PR DESCRIPTION
there are many functions which are available in scala is also available in DynamicFrame python API, missing from documentation, it would be good idea if we can add that information here
ex.
repartition
coalesce

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
