### PR TITLE
Fix variable name typo for myNewJobRun

### DIFF
--- a/doc_source/aws-glue-programming-python-calling.md
+++ b/doc_source/aws-glue-programming-python-calling.md
@@ -88,7 +88,7 @@ The following example shows how call the AWS Glue APIs using Python, to create a
 1. Get the job status:
 
    ```
-   status = glue.get_job_run(JobName=myJob['Name'], RunId=JobRun['JobRunId'])
+   status = glue.get_job_run(JobName=myJob['Name'], RunId=myNewJobRun['JobRunId'])
    ```
 
 1. Print the current state of the job run:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The variable name `myNewJobRun` is created in step 3, but in step 4 it is referenced as `JobRun`. This PR fixes that inconsistency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
