### PR TITLE
Add Missing reference to FlatMap Class in summary

### DIFF
--- a/doc_source/aws-glue-programming-python-transforms.md
+++ b/doc_source/aws-glue-programming-python-transforms.md
@@ -7,6 +7,7 @@ AWS Glue has created the following transform Classes to use in PySpark ETL opera
 + [DropNullFields Class](aws-glue-api-crawler-pyspark-transforms-DropNullFields.md)
 + [ErrorsAsDynamicFrame Class](aws-glue-api-crawler-pyspark-transforms-ErrorsAsDynamicFrame.md)
 + [Filter Class](aws-glue-api-crawler-pyspark-transforms-filter.md)
++ [FlatMap Class](aws-glue-api-crawler-pyspark-transforms-flat-map.md)
 + [Join Class](aws-glue-api-crawler-pyspark-transforms-join.md)
 + [Map Class](aws-glue-api-crawler-pyspark-transforms-map.md)
 + [MapToCollection Class](aws-glue-api-crawler-pyspark-transforms-MapToCollection.md)


### PR DESCRIPTION
The reference to FlatMap Class was missing from the summary whereas this class is available and already documented.

*Description of changes:*
Added the missing reference in the summary to the already existing markdown file.

I don't know why it seems that there is an update of the last line, I didn't touched it and it the exact same line, sorry.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
