### PR TITLE
Adds the log-group label for the Glue log permissions reference

### DIFF
--- a/doc_source/create-service-policy.md
+++ b/doc_source/create-service-policy.md
@@ -90,7 +90,7 @@ Add any permissions needed for Amazon S3 resources\. You might want to scope the
                    "logs:AssociateKmsKey"                
                ],
                "Resource": [
-                   "arn:aws:logs:*:*:/aws-glue/*"
+                   "arn:aws:logs:*:*:log-group:/aws-glue/*"
                ]
            },
            {


### PR DESCRIPTION
*Issue #, if available:*
None available
*Description of changes:*
There is a missing label in the CloudWatch Logs permissions statement for an AWS Glue service role. A small change fixes it. This was tested in a live AWS environment to confirm it works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
