### PR TITLE
changes in glue docs - getResolvedOptions

### DIFF
--- a/doc_source/aws-glue-api-crawler-pyspark-extensions-get-resolved-options.md
+++ b/doc_source/aws-glue-api-crawler-pyspark-extensions-get-resolved-options.md
@@ -30,8 +30,7 @@ import sys
 from awsglue.utils import getResolvedOptions
 
 args = getResolvedOptions(sys.argv,
-                          ['JOB_NAME',
-                           'day_partition_key',
+                          ['day_partition_key',
                            'hour_partition_key',
                            'day_partition_value',
                            'hour_partition_value'])


### PR DESCRIPTION
Delete Job name from getResolvedOptions

*Issue #, if available:*

*Description of changes:*
In documentation https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-crawler-pyspark-extensions-get-resolved-options.html the JOB_NAME parameter in the function getResolvedOptions is not correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
