### PR TITLE
Clarify communication direction for AWS Glue VPC Endpoints

### DIFF
--- a/doc_source/vpc-endpoint.md
+++ b/doc_source/vpc-endpoint.md
@@ -1,8 +1,8 @@
 # Using AWS Glue with VPC Endpoints<a name="vpc-endpoint"></a>
 
-If you use Amazon Virtual Private Cloud \(Amazon VPC\) to host your AWS resources, you can establish a private connection between your VPC and AWS Glue\. You use this connection to enable AWS Glue to communicate with the resources in your VPC without going through the public internet\.
+If you use Amazon Virtual Private Cloud \(Amazon VPC\) to host your AWS resources, you can establish a private connection between your VPC and AWS Glue\. You use this connection to enable the resources in your VPC to communicate with AWS Glue without going through the public internet\.
 
-Amazon VPC is an AWS service that you can use to launch AWS resources in a virtual network that you define\. With a VPC, you have control over your network settings, such the IP address range, subnets, route tables, and network gateways\. To connect your VPC to AWS Glue, you define an interface VPC endpoint for AWS Glue\. When you use a VPC interface endpoint, communication between your VPC and AWS Glue is conducted entirely and securely within the AWS network\.
+Amazon VPC is an AWS service that you can use to launch AWS resources in a virtual network that you define\. With a VPC, you have control over your network settings, such the IP address range, subnets, route tables, and network gateways\. To connect your VPC to AWS Glue, you define an interface VPC endpoint for AWS Glue\. When you use a VPC interface endpoint, communication from your VPC to AWS Glue is conducted entirely and securely within the AWS network\.
 
 You can use AWS Glue with VPC endpoints in all AWS Regions that support both AWS Glue and Amazon VPC endpoints\.
 


### PR DESCRIPTION
The documentation as it stands is misleading. Creation of a VPC Endpoint for Glue does not (as far as I understand it) facilitate connections from Glue jobs to your VPC resources - rather, from the VPC to the AWS Glue API. The case of Glue to VPC communications is handled by Glue Network Connections.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
