### PR TITLE
Updated content for Setup VPC for Glue Access for Best Practices and Security

### DIFF
--- a/doc_source/setup-vpc-for-glue-access.md
+++ b/doc_source/setup-vpc-for-glue-access.md
@@ -1,6 +1,6 @@
 # Setting Up a VPC to Connect to JDBC Data Stores<a name="setup-vpc-for-glue-access"></a>
 
-To enable AWS Glue components to communicate, you must set up access to your data stores, such as Amazon Redshift and Amazon RDS\. In order for VPC Functionality to work AWS Glue needs to communicate between its components, create a security group with a self\-referencing inbound rule for all TCP ports\. By creating a self\-referencing rule, you can restrict the source to the same security group in the VPC, and it's not open to all networks\.
+To enable AWS Glue components to communicate, you must set up access to your data stores, such as Amazon Redshift and Amazon RDS\. In order for VPC Functionality to work AWS Glue needs to communicate between its components, create a security group with a self\-referencing inbound rule for all TCP ports\. By creating a self\-referencing rule, you can restrict the source to the same security group in the VPC, and it's not open to all networks\. See more about [Security Groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html)\.
 
 ## ****To set up access for AWS Glue****
 


### PR DESCRIPTION
*Description of changes:*
1) The current documentation in confusing and does conform to security best practices. It uses a single self-referencing security group of ALL TCP ALL PORTS for Glue, Redshift and RDS. Redshift/RDS only expose a single port from the service and most security teams will not approve ALLOW ALL on a database. Only Glue needs the self-referencing rule for the Hadoop/Spark components to communicate, this is confusing from the way the current docs read. I delineated these security groups into Glue, Redshift and RDS with appropriate sg references.

2) Removed static image assets as the screenshot was already out of date, changed these to table form (may need styles applied)

3) Included more verbose content including more verbiage on Glue at the top and then also providing extra security group examples for each engine type of RDS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
