### PR TITLE
Update Glue Schema Registry version

### DIFF
--- a/doc_source/schema-registry-gs.md
+++ b/doc_source/schema-registry-gs.md
@@ -31,7 +31,7 @@ To install the libraries on producers and consumers:
    <dependency>
        <groupId>software.amazon.glue</groupId>
        <artifactId>schema-registry-serde</artifactId>
-       <version>1.0.0</version>
+       <version>1.1.5</version>
    </dependency>
    ```
 


### PR DESCRIPTION
Upgrading to latest version of Glue schema registry library.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
