### PR TITLE
Updated mutiple .egg/.whl file usage

### DIFF
--- a/doc_source/add-job-python.md
+++ b/doc_source/add-job-python.md
@@ -197,7 +197,7 @@ If you aren't sure how to create an `.egg` or a `.whl` file from a Python librar
 
    ```
    aws glue create-job --name python-redshift-test-cli --role Role --command '{"Name" :  "pythonshell", "ScriptLocation" : "s3://MyBucket/python/library/redshift_test.py"}' 
-        --connections Connections="connection-name" --default-arguments '{"--extra-py-files" : ["s3://MyBucket/python/library/redshift_module-0.1-py2.7.egg", "s3://MyBucket/python/library/redshift_module-0.1-py2.7-none-any.whl"]}'
+        --connections Connections="connection-name" --default-arguments '{"--extra-py-files" : "s3://MyBucket/python/library/redshift_module-0.1-py2.7.egg, s3://MyBucket/python/library/redshift_module-0.1-py2.7-none-any.whl"}'
    ```
 
    When the job runs, the script prints the rows created in the *table\_name* table in the Amazon Redshift cluster\.


### PR DESCRIPTION
# Overview
The current version has an incorrect example as it uses a `list` rather a `string` for multiple .egg/.whl files. The error one gets with the current version is:

```
Invalid type for parameter DefaultArguments.--extra-py-files, value: [ "s3://MyBucket/python/library/redshift_module-0.1-py2.7.egg", "s3://MyBucket/python/library/redshift_module-0.1-py2.7-none-any.whl"}'], type: <class 'list'>, valid types: <class 'str'>
```

I fixed the example to be a single string and work.

I followed the guide at https://github.com/awsdocs/aws-glue-developer-guide/blob/dcc61af4ac767d1b68bed4f597866558442ea2ba/CONTRIBUTING.md#how-to-contribute for this PR. Since this is a documentation fix, I did not create an issue for it.

*Issue #, if available:* 

 N/A

*Description of changes:*

Documentation fix for page: https://docs.aws.amazon.com/glue/latest/dg/add-job-python.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
