### PR TITLE
remove duplicate module in  python module list

### DIFF
--- a/doc_source/aws-glue-programming-python-libraries.md
+++ b/doc_source/aws-glue-programming-python-libraries.md
@@ -58,7 +58,6 @@ AWS Glue version 2\.0 supports the following python modules out of the box:
 + s3transfer==0\.3\.3
 + scikit\-learn==0\.22\.1
 + scipy==1\.4\.1
-+ setuptools==45\.2\.0 
 + setuptools==45\.2\.0
 + six==1\.14\.0
 + statsmodels==0\.11\.1


### PR DESCRIPTION
The setuptools module is listed twice in the python supported modules list, I've removed the duplicate.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
