### PR TITLE
Update aws-glue-api-crawler-pyspark-extensions-glue-context.md

### DIFF
--- a/doc_source/aws-glue-api-crawler-pyspark-extensions-glue-context.md
+++ b/doc_source/aws-glue-api-crawler-pyspark-extensions-glue-context.md
@@ -72,7 +72,7 @@ If you're running AWS Glue ETL jobs that read files or partitions from Amazon S3
   + `accountId` – The Amazon Web Services account ID to run the transition transform\. Mandatory for this transform\.
   + `roleArn` – The AWS role to run the transition transform\. Mandatory for this transform\.
 + `transformation_ctx` – The transformation context to use \(optional\)\. Used in the manifest file path\.
-+ `catalog_id` – The catalog ID of the Data Catalog being accessed \(the account ID of the Data Catalog\)\. Set to `None` by default\. `None` defaults to the catalog ID of the calling account in the service\.
++ `catalog_id` – The catalog ID of the Data Catalog being accessed \(the account ID of the Data Catalog\) as string type\. Set to `None` by default\. `None` defaults to the catalog ID of the calling account in the service\.
 
 **Example**  
 


### PR DESCRIPTION
Make clear that catalog_id is string (this is clear in the Scala documentation).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
